### PR TITLE
feat: 增加终端加粗下划线光标设置选项 (#270)

### DIFF
--- a/3rdparty/terminalwidget/lib/Emulation.h
+++ b/3rdparty/terminalwidget/lib/Emulation.h
@@ -138,7 +138,12 @@ public:
          * An cursor shaped like the capital letter 'I', similar to the IBeam
          * cursor used in Qt/KDE text editors.
          */
-        IBeamCursor = 2
+        IBeamCursor = 2,
+        /**
+         * A rectangular block which covers the bottom area of the cursor character. 
+         * Easier to discover under underlined strings.
+         */
+        BoldUnderlineCursor = 3
     };
 
 

--- a/3rdparty/terminalwidget/lib/TerminalDisplay.cpp
+++ b/3rdparty/terminalwidget/lib/TerminalDisplay.cpp
@@ -776,6 +776,23 @@ void TerminalDisplay::drawCursor(QPainter& painter,
                              		cursorRect.top()),
                                 QPointF(cursorRect.left(),
                              		cursorRect.bottom())));
+       else if ( _cursorShape == Emulation::KeyboardCursorShape::BoldUnderlineCursor )
+        { 
+            if ( hasFocus() )
+            {
+                cursorRect.translate(0,cursorRect.height());
+                cursorRect.setHeight(4);
+                painter.fillRect(cursorRect, _cursorColor.isValid() ? _cursorColor : foregroundColor);
+            }
+            else
+            {
+                painter.drawRect(
+                                cursorRect.left(),
+                                cursorRect.bottom(),
+                                cursorRect.width(),
+                                4);
+            }
+        }
     }
 }
 

--- a/3rdparty/terminalwidget/lib/Vt102Emulation.cpp
+++ b/3rdparty/terminalwidget/lib/Vt102Emulation.cpp
@@ -659,6 +659,8 @@ void Vt102Emulation::processToken(int token, wchar_t p, int q)
     case TY_CSI_PS_SP('q',   4) : emit cursorChanged(KeyboardCursorShape::UnderlineCursor, false); break;
     case TY_CSI_PS_SP('q',   5) : emit cursorChanged(KeyboardCursorShape::IBeamCursor,     true ); break;
     case TY_CSI_PS_SP('q',   6) : emit cursorChanged(KeyboardCursorShape::IBeamCursor,     false); break;
+    case TY_CSI_PS_SP('q',   7) : emit cursorChanged(KeyboardCursorShape::BoldUnderlineCursor, true ); break;
+    case TY_CSI_PS_SP('q',   8) : emit cursorChanged(KeyboardCursorShape::BoldUnderlineCursor, false); break;
 
     case TY_CSI_PN('@'      ) : _currentScreen->insertChars          (p         ); break;
     case TY_CSI_PN('A'      ) : _currentScreen->cursorUp             (p         ); break; //VT100

--- a/src/assets/other/default-config.json
+++ b/src/assets/other/default-config.json
@@ -308,7 +308,7 @@
                             "key": "cursor_shape",
                             "name": "Cursor style",
                             "type": "buttongroup",
-                            "items": ["▐","_","|"],
+                            "items": ["▐","_","|","▂"],
                             "default": 0,
                             "i18n_skip_keys": ["items"]
                         },


### PR DESCRIPTION
Description: 在终端使用vi/vim编辑器,或者光标在具有下划线的字符串时,单像素下划线光标很难被发现。使用加粗下划线(4像素)能够快速发现光标位置,提升体验。目前已知问题:例如在vim里面高亮选择的内容是上下行时,此时光标位置处,因为第三方库的选择区域高度,导致色块连接,让加粗下划线显示为1像素的横线。

Log: 增加终端加粗下划线光标设置选项,增强用户使用体验